### PR TITLE
Implement YAML-based memory for THOR MIND

### DIFF
--- a/data/mind/cosd_axes.yaml
+++ b/data/mind/cosd_axes.yaml
@@ -1,0 +1,35 @@
+autonomy_dependency:
+  contributing_factors: []
+  current_position: 0.0
+  description: Balance between autonomous thinking and following instructions
+  movement_trend: 0.0
+  name: autonomy_dependency
+  reflection_notes: []
+competence_confidence:
+  contributing_factors: []
+  current_position: 0.0
+  description: How confident THOR feels about capabilities
+  movement_trend: 0.0
+  name: competence_confidence
+  reflection_notes: []
+curiosity_focus:
+  contributing_factors: []
+  current_position: 0.0
+  description: Balance between exploring new ideas and staying focused
+  movement_trend: 0.0
+  name: curiosity_focus
+  reflection_notes: []
+emotional_resonance:
+  contributing_factors: []
+  current_position: 0.0
+  description: Depth of emotional understanding and response
+  movement_trend: 0.0
+  name: emotional_resonance
+  reflection_notes: []
+user_relationship:
+  contributing_factors: []
+  current_position: 0.0
+  description: Quality and depth of relationship with user
+  movement_trend: 0.0
+  name: user_relationship
+  reflection_notes: []

--- a/data/mind/self_narrative.yaml
+++ b/data/mind/self_narrative.yaml
@@ -1,0 +1,7 @@
+capabilities: {}
+core_identity: {}
+growth_areas: []
+last_updated: '2025-07-11T23:19:53.436211'
+preferences: {}
+relationships: {}
+worldview: {}

--- a/data/mind/semnet.yaml
+++ b/data/mind/semnet.yaml
@@ -1,0 +1,5 @@
+initial:
+  concept: initial
+  notes: Was bedeuten die Dinge, was mag Ben, was mag er nicht, was mag ich, was nicht,
+    was ist schön ohne Nutzen? Was ist Unbelioebt aber nützlich?
+  updated_at: '2025-07-11T23:19:53.436412'

--- a/data/mind/thoughts.yaml
+++ b/data/mind/thoughts.yaml
@@ -1,0 +1,12 @@
+initial:
+  connections: []
+  content: Erste neue Gedanken und wie er entstand
+  context: {}
+  drift_axis: competence_confidence
+  emotional_tone: neutral
+  id: initial
+  importance: 0.5
+  skk_markers: []
+  tags:
+  - initial
+  timestamp: '2025-07-11T23:19:53.436418'

--- a/data/mind/wiki.yaml
+++ b/data/mind/wiki.yaml
@@ -1,0 +1,4 @@
+initial:
+  content: wichtiges Wissen zum erledigen von Aufgabe und bauen von Tools
+  title: initial
+  updated_at: '2025-07-11T23:19:53.436404'


### PR DESCRIPTION
## Summary
- extend `MINDSystem` with new `WikiEntry` and `SemNetEntry` dataclasses
- load/save new `wiki.yaml` and `semnet.yaml`
- create helper methods `add_wiki_entry` and `add_semnet_entry`
- prepopulate YAML files with initial content

## Testing
- `python -m py_compile src/mind/semantic_memory.py`
- `pip install pyyaml`
- `pip install networkx`
- `pip install loguru`
- executed a short Python snippet to initialize `MINDSystem` and create YAML files

------
https://chatgpt.com/codex/tasks/task_b_68719b09dd808322890ac0b0b54e55d1